### PR TITLE
"SECRET_KEY setting must not be empty"

### DIFF
--- a/cobbler/Dockerfile
+++ b/cobbler/Dockerfile
@@ -35,7 +35,7 @@ RUN git clone --branch $COBBLER_GIT_TAG $COBBLER_GIT_URL && cd cobbler && \
     make && \
     make install && \
     ln -s /srv/tftpboot /var/lib/tftpboot && \
-    echo "SECRET_KEY='$COBBLER_SECRET_KEY'" >> /usr/local/share/cobbler/web/settings.py && \
+    echo "SECRET_KEY='$COBBLER_SECRET_KEY'" >> /usr/local/lib/python3.6/dist-packages/cobbler/web/settings.py && \
     sed -i "s|^INTERFACESv4=.*|INTERFACESv4='eth0'|g" /etc/default/isc-dhcp-server && \
     echo "lanplus=1" >> /etc/cobbler/power/fence_ipmilan.template && \
     touch /var/lib/dhcp/dhcpd.leases && \


### PR DESCRIPTION
When browsing to the webui (<server>/cobbler_web) getting error: `500 - Internal Server Error - The server encountered an internal error or misconfiguration and was unable to complete your request`.  Docker logs show:

> [Fri May 08 18:51:39.197173 2020] [wsgi:error] [pid 18:tid 139682863122176] [remote 10.0.0.2:16507] mod_wsgi (pid=18): Exception occurred processing WSGI script '/usr/local/share/cobbler/web/cobbler.wsgi'.
...
10.0.0.2:16507] django.core.exceptions.ImproperlyConfigured: The SECRET_KEY setting must not be empty.   


Perhaps the path to settings.py changed between bionic base versions.  Anyway, this fixes.