### PR TITLE
Fix for "TemplateDoesNotExist" 500 error when browsing to webui

### DIFF
--- a/cobbler/Dockerfile
+++ b/cobbler/Dockerfile
@@ -51,6 +51,7 @@ RUN service apache2 start && \
     cobbler signature update && \
     cobbler get-loaders && \
     cobbler sync && \
+    ln -s /usr/local/share/cobbler /usr/share/ && \
     cp /usr/lib/grub/x86_64-efi-signed/grubnetx64.efi.signed /srv/tftpboot/grubx64.efi && \
     cp /usr/lib/ipxe/undionly.kpxe /srv/tftpboot/undionly.kpxe && \
     mv /var/lib/cobbler/snippets /var/lib/cobbler/autoinstall_snippets && \


### PR DESCRIPTION
When browsing to the webui (/cobbler_web) getting error: `500 - Internal Server Error - The server encountered an internal error or misconfiguration and was unable to complete your request.` Docker logs show:
`django.template.exceptions.TemplateDoesNotExist: login.tmpl`
and
`pytz.exceptions.UnknownTimeZoneError: None`

Cobbler expects the content of /usr/local/share/cobbler to be in /usr/share/cobbler so I have symlinked to fix.